### PR TITLE
chore: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+#
+*                       @equinix/governor-devrel-engineering
+*fabricv*               @equinix/governor-digin-fabric


### PR DESCRIPTION
This adds a code ownership mappings similar to what we have for other SDKs so that individual teams can continue to own the parts of the SDK that are relevant to them.