### PR TITLE
chore: remove unnecessary & broken checkout command

### DIFF
--- a/.github/workflows/auto-commit-client-updates.yml
+++ b/.github/workflows/auto-commit-client-updates.yml
@@ -27,9 +27,6 @@ jobs:
           git config --global user.name 'equinix-labs@auto-commit-workflow'
           git config --global user.email 'bot@equinix.noreply.github.com'
           git config advice.addIgnoredFile false
-          git fetch
-          echo -e "\nThis is executing for branch: ${GITHUB_REF##*/}."
-          git checkout ${GITHUB_REF##*/}          
           make generate-all
 
       - name: Commit to branch.


### PR DESCRIPTION
The autocommit workflow was executing an unnecessary checkout command in order to fetch code from the branch that triggered the workflow.  That code is already checked out by default in the first step of the workflow, using `actions/checkout`.

The unnecessary checkout command included some logic to translate the `GITHUB_REF` environment variable into a usable branch name, but that transformation assumed that branch names never include a `/`.  That is not a correct assumption and caused the workflow to fail for sync PRs, which use branches with names like `sync/<something>`.

Removing the unnecessary checkout command fixes the workflow so that it will be able to work with any branch name.