### PR TITLE
ci: updated

### DIFF
--- a/.github/workflows/fabricv4_test_runner.yml
+++ b/.github/workflows/fabricv4_test_runner.yml
@@ -1,6 +1,9 @@
 name: Test Equinix SDK Java Runner
 
 on:
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -187,3 +190,4 @@ jobs:
                   *Test Runs:* ${{ needs.test.outputs.tests_run }}
                   *Results:* ${{ steps.set-output-passed.outputs.total_passed }} Passed, ${{ steps.set-output-failed.outputs.total_failed }} Failed
                   *Triggered by:* <@${{ github.actor }}>
+                  *Responsibility:* <@U04AM0XBJMA>

--- a/.github/workflows/fabricv4_test_runner.yml
+++ b/.github/workflows/fabricv4_test_runner.yml
@@ -75,8 +75,8 @@ jobs:
         run: |
           mvn test \
             -Dtest=${{ matrix.testConfig.class }} \
-            -DenvUrl="${{ secrets.TEST_HOST_URL }}" \
-            -DuatUsers="${{ secrets.TEST_DATA_UAT_USERS }}" \
+            -DenvUrl='${{ secrets.TEST_HOST_URL }}' \
+            -DuatUsers='${{ secrets.TEST_DATA_UAT_USERS }}' \
             -Djava.version=${{ matrix.testConfig.jdk }} \
             -Dmaven.compiler.source=${{ matrix.testConfig.jdk }} \
             -Dmaven.compiler.target=${{ matrix.testConfig.jdk }}

--- a/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/CloudRoutersApiTest.java
+++ b/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/CloudRoutersApiTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.*;
  */
 public class CloudRoutersApiTest {
 
-    private static final UsersItem.UserName userName = UsersItem.UserName.PANTHERS_FNV;
+    private static final UsersItem.UserName userName = UsersItem.UserName.PANTHERS_FCR;
 
     public static void removeCloudRouters(UsersItem.UserName userName) {
         users.get(userName).getUserResources().getCloudRoutersUuid().forEach(uuid -> {

--- a/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/NetworksApiTest.java
+++ b/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/NetworksApiTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertFalse;
  * API tests for NetworksApi
  */
 public class NetworksApiTest {
-    private static final UsersItem.UserName userName = UsersItem.UserName.PANTHERS_FNV;
+    private static final UsersItem.UserName userName = UsersItem.UserName.PANTHERS_FCR;
 
     public static void removeNetworks(UsersItem.UserName userName) {
         users.get(userName).getUserResources().getNetworksUuid().forEach(NetworksApiTest::deleteNetwork);

--- a/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/RoutingProtocolsApiTest.java
+++ b/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/RoutingProtocolsApiTest.java
@@ -130,7 +130,7 @@ public class RoutingProtocolsApiTest {
                 break;
             }
             try {
-                Thread.sleep(3000);
+                Thread.sleep(10000);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
- Update slack notification - add responsible person to mention on the channel for executed tests
- Fixed tests

This pull request updates the Equinix Fabric v4 test runner workflow and several test classes to improve test reliability and clarify test responsibility. The main changes include triggering the workflow on pull requests, updating test user references, increasing wait times for provisioning, and adding responsibility information to workflow notifications.

**CI/CD Workflow Improvements:**

* The `.github/workflows/fabricv4_test_runner.yml` workflow is now triggered on pull requests to the `main` branch, ensuring tests run automatically for new changes.
* Added a responsibility line to workflow notifications to clarify who is accountable for test results.
* Updated the syntax for passing secrets to Maven test commands to use single quotes for consistency and reliability.

**Test Reliability and Maintenance:**

* Changed the test user reference from `PANTHERS_FNV` to `PANTHERS_FCR` in both `CloudRoutersApiTest` and `NetworksApiTest` to ensure tests use the correct user context. (`equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/CloudRoutersApiTest.java` [[1]](diffhunk://#diff-8b865f8b9a2dc2e8f38cc5a4172f519cdca8da8313570d27bc9df873e5a6641fL33-R33) `equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/NetworksApiTest.java` [[2]](diffhunk://#diff-2a27a50e4789760c31008ff352e94a51d3ab833ad6a8056be66cebb61a297e19L33-R33)
* Increased the sleep interval in `RoutingProtocolsApiTest.waitForBGPTypeIsProvisioned` from 3 seconds to 10 seconds to improve reliability when waiting for resource provisioning. (`equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/RoutingProtocolsApiTest.java` [equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/RoutingProtocolsApiTest.javaL133-R133](diffhunk://#diff-f6eb188e4a822ac1200cc2f2cf3d3c528e4c3d4202f2f1b28f72a49fea449313L133-R133))