### PR TITLE
test: add read-only integration tests for Agents and AgentTemplates API

### DIFF
--- a/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/AgentTemplatesApiTest.java
+++ b/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/AgentTemplatesApiTest.java
@@ -1,0 +1,43 @@
+package com.equinix.openapi.fabric.tests;
+
+import com.equinix.openapi.fabric.tests.dto.users.UsersItem;
+import com.equinix.sdk.fabricv4.ApiException;
+import com.equinix.sdk.fabricv4.model.*;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static com.equinix.openapi.fabric.tests.helpers.Apis.*;
+import static org.junit.Assert.*;
+
+/**
+ * API tests for AgentTemplatesApi
+ */
+public class AgentTemplatesApiTest {
+
+    private static final UsersItem.UserName userName = UsersItem.UserName.PANTHERS_FCR;
+
+    @BeforeClass
+    public static void setUp() {
+        setUserName(userName);
+    }
+
+    @Test
+    public void getAgentTemplates() throws ApiException {
+        AgentTemplateGetAllResponse response = agentTemplatesApi.getAgentTemplates(null, null);
+        assertEquals(200, agentTemplatesApi.getApiClient().getStatusCode());
+        assertNotNull(response.getData());
+    }
+
+    @Test
+    public void getAgentTemplateByUuid() throws ApiException {
+        AgentTemplateGetAllResponse templates = agentTemplatesApi.getAgentTemplates(null, null);
+        assertFalse("No agent templates available", templates.getData().isEmpty());
+        UUID templateUuid = templates.getData().get(0).getUuid();
+
+        AgentTemplates template = agentTemplatesApi.getAgentTemplateByUuid(templateUuid, null, null);
+        assertEquals(200, agentTemplatesApi.getApiClient().getStatusCode());
+        assertEquals(templateUuid, template.getUuid());
+    }
+}

--- a/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/AgentsApiTest.java
+++ b/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/AgentsApiTest.java
@@ -1,0 +1,53 @@
+package com.equinix.openapi.fabric.tests;
+
+import com.equinix.openapi.fabric.tests.dto.users.UsersItem;
+import com.equinix.sdk.fabricv4.ApiException;
+import com.equinix.sdk.fabricv4.model.*;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static com.equinix.openapi.fabric.tests.helpers.Apis.*;
+import static org.junit.Assert.*;
+
+/**
+ * API tests for AgentsApi
+ */
+public class AgentsApiTest {
+
+    private static final UsersItem.UserName userName = UsersItem.UserName.PANTHERS_FCR;
+
+    @BeforeClass
+    public static void setUp() {
+        setUserName(userName);
+    }
+
+    private static Agents getFirstAgent() throws ApiException {
+        AgentGetAllResponse response = agentsApi.getAgents(null, null);
+        Assume.assumeTrue("No agents available", !response.getData().isEmpty());
+        return response.getData().get(0);
+    }
+
+    @Test
+    public void getAgents() throws ApiException {
+        AgentGetAllResponse response = agentsApi.getAgents(null, null);
+        assertEquals(200, agentsApi.getApiClient().getStatusCode());
+        assertNotNull(response.getData());
+    }
+
+    @Test
+    public void getAgentByUuid() throws ApiException {
+        Agents agent = getFirstAgent();
+        Agents agentGet = agentsApi.getAgentByUuid(agent.getUuid(), null, null);
+        assertEquals(200, agentsApi.getApiClient().getStatusCode());
+        assertEquals(agent.getUuid(), agentGet.getUuid());
+    }
+
+    @Test
+    public void getAgentActivities() throws ApiException {
+        Agents agent = getFirstAgent();
+        AgentGetActivities activities = agentsApi.getAgentActivities(agent.getUuid(), null, null);
+        assertEquals(200, agentsApi.getApiClient().getStatusCode());
+        assertNotNull(activities);
+    }
+}

--- a/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/dto/users/UsersItem.java
+++ b/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/dto/users/UsersItem.java
@@ -35,6 +35,9 @@ public class UsersItem {
     @JsonProperty("iaProfileUuid")
     private String iaProfileUuid;
 
+    @JsonProperty("agentsProjectId")
+    private String agentsProjectId;
+
     public List<PortDto> getPorts() {
         return ports;
     }
@@ -105,6 +108,14 @@ public class UsersItem {
 
     public void setIaProfileUuid(String iaProfileUuid) {
         this.iaProfileUuid = iaProfileUuid;
+    }
+
+    public String getAgentsProjectId() {
+        return agentsProjectId;
+    }
+
+    public void setAgentsProjectId(String agentsProjectId) {
+        this.agentsProjectId = agentsProjectId;
     }
 
     public enum UserName {

--- a/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/helpers/Apis.java
+++ b/equinix-openapi-fabric-tests/src/test/java/com/equinix/openapi/fabric/tests/helpers/Apis.java
@@ -6,6 +6,8 @@ import com.equinix.sdk.fabricv4.api.*;
 import static com.equinix.openapi.fabric.tests.helpers.TokenGenerator.generate;
 
 public class Apis {
+    public static AgentsApi agentsApi;
+    public static AgentTemplatesApi agentTemplatesApi;
     public static CloudRoutersApi cloudRoutersApi;
     public static ConnectionsApi connectionsApi;
     public static HealthApi healthApi;
@@ -40,6 +42,8 @@ public class Apis {
     }
 
     private static void setApis() {
+        agentsApi = new AgentsApi(TokenGenerator.getApiClient(currentUser));
+        agentTemplatesApi = new AgentTemplatesApi(TokenGenerator.getApiClient(currentUser));
         cloudRoutersApi = new CloudRoutersApi(TokenGenerator.getApiClient(currentUser));
         connectionsApi = new ConnectionsApi(TokenGenerator.getApiClient(currentUser));
         healthApi = new HealthApi(TokenGenerator.getApiClient(currentUser));

--- a/patches/services/fabricv4/002-fix-agent-templates-href-type.patch
+++ b/patches/services/fabricv4/002-fix-agent-templates-href-type.patch
@@ -1,0 +1,88 @@
+diff --git a/services/fabricv4/src/main/java/com/equinix/sdk/fabricv4/model/AgentActivities.java b/services/fabricv4/src/main/java/com/equinix/sdk/fabricv4/model/AgentActivities.java
+index 2d186dae..d982eacb 100644
+--- a/services/fabricv4/src/main/java/com/equinix/sdk/fabricv4/model/AgentActivities.java
++++ b/services/fabricv4/src/main/java/com/equinix/sdk/fabricv4/model/AgentActivities.java
+@@ -23,6 +23,7 @@ import com.google.gson.stream.JsonReader;
+ import com.google.gson.stream.JsonWriter;
+ import java.io.IOException;
+ import java.util.Arrays;
++import java.net.URI;
+ import java.util.UUID;
+ 
+ import com.google.gson.Gson;
+@@ -57,7 +58,7 @@ public class AgentActivities {
+   public static final String SERIALIZED_NAME_HREF = "href";
+   @SerializedName(SERIALIZED_NAME_HREF)
+   @javax.annotation.Nullable
+-  private UUID href;
++  private URI href;
+ 
+   public static final String SERIALIZED_NAME_TYPE = "type";
+   @SerializedName(SERIALIZED_NAME_TYPE)
+@@ -99,7 +100,7 @@ public class AgentActivities {
+     this.uuid = uuid;
+   }
+ 
+-  public AgentActivities href(@javax.annotation.Nullable UUID href) {
++  public AgentActivities href(@javax.annotation.Nullable URI href) {
+     this.href = href;
+     return this;
+   }
+@@ -109,11 +110,11 @@ public class AgentActivities {
+    * @return href
+    */
+   @javax.annotation.Nullable
+-  public UUID getHref() {
++  public URI getHref() {
+     return href;
+   }
+ 
+-  public void setHref(@javax.annotation.Nullable UUID href) {
++  public void setHref(@javax.annotation.Nullable URI href) {
+     this.href = href;
+   }
+ 
+diff --git a/services/fabricv4/src/main/java/com/equinix/sdk/fabricv4/model/AgentTemplates.java b/services/fabricv4/src/main/java/com/equinix/sdk/fabricv4/model/AgentTemplates.java
+index c0acfb7c..d80d920b 100644
+--- a/services/fabricv4/src/main/java/com/equinix/sdk/fabricv4/model/AgentTemplates.java
++++ b/services/fabricv4/src/main/java/com/equinix/sdk/fabricv4/model/AgentTemplates.java
+@@ -22,6 +22,7 @@ import com.google.gson.stream.JsonReader;
+ import com.google.gson.stream.JsonWriter;
+ import java.io.IOException;
+ import java.util.Arrays;
++import java.net.URI;
+ import java.util.UUID;
+ 
+ import com.google.gson.Gson;
+@@ -56,7 +57,7 @@ public class AgentTemplates {
+   public static final String SERIALIZED_NAME_HREF = "href";
+   @SerializedName(SERIALIZED_NAME_HREF)
+   @javax.annotation.Nullable
+-  private UUID href;
++  private URI href;
+ 
+   public static final String SERIALIZED_NAME_TYPE = "type";
+   @SerializedName(SERIALIZED_NAME_TYPE)
+@@ -161,7 +162,7 @@ public class AgentTemplates {
+   public AgentTemplates() {
+   }
+ 
+-  public AgentTemplates href(@javax.annotation.Nullable UUID href) {
++  public AgentTemplates href(@javax.annotation.Nullable URI href) {
+     this.href = href;
+     return this;
+   }
+@@ -171,11 +172,11 @@ public class AgentTemplates {
+    * @return href
+    */
+   @javax.annotation.Nullable
+-  public UUID getHref() {
++  public URI getHref() {
+     return href;
+   }
+ 
+-  public void setHref(@javax.annotation.Nullable UUID href) {
++  public void setHref(@javax.annotation.Nullable URI href) {
+     this.href = href;
+   }
+ 

--- a/services/fabricv4/src/main/java/com/equinix/sdk/fabricv4/model/AgentActivities.java
+++ b/services/fabricv4/src/main/java/com/equinix/sdk/fabricv4/model/AgentActivities.java
@@ -23,6 +23,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
+import java.net.URI;
 import java.util.UUID;
 
 import com.google.gson.Gson;
@@ -57,7 +58,7 @@ public class AgentActivities {
   public static final String SERIALIZED_NAME_HREF = "href";
   @SerializedName(SERIALIZED_NAME_HREF)
   @javax.annotation.Nullable
-  private UUID href;
+  private URI href;
 
   public static final String SERIALIZED_NAME_TYPE = "type";
   @SerializedName(SERIALIZED_NAME_TYPE)
@@ -99,7 +100,7 @@ public class AgentActivities {
     this.uuid = uuid;
   }
 
-  public AgentActivities href(@javax.annotation.Nullable UUID href) {
+  public AgentActivities href(@javax.annotation.Nullable URI href) {
     this.href = href;
     return this;
   }
@@ -109,11 +110,11 @@ public class AgentActivities {
    * @return href
    */
   @javax.annotation.Nullable
-  public UUID getHref() {
+  public URI getHref() {
     return href;
   }
 
-  public void setHref(@javax.annotation.Nullable UUID href) {
+  public void setHref(@javax.annotation.Nullable URI href) {
     this.href = href;
   }
 

--- a/services/fabricv4/src/main/java/com/equinix/sdk/fabricv4/model/AgentTemplates.java
+++ b/services/fabricv4/src/main/java/com/equinix/sdk/fabricv4/model/AgentTemplates.java
@@ -22,6 +22,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
+import java.net.URI;
 import java.util.UUID;
 
 import com.google.gson.Gson;
@@ -56,7 +57,7 @@ public class AgentTemplates {
   public static final String SERIALIZED_NAME_HREF = "href";
   @SerializedName(SERIALIZED_NAME_HREF)
   @javax.annotation.Nullable
-  private UUID href;
+  private URI href;
 
   public static final String SERIALIZED_NAME_TYPE = "type";
   @SerializedName(SERIALIZED_NAME_TYPE)
@@ -161,7 +162,7 @@ public class AgentTemplates {
   public AgentTemplates() {
   }
 
-  public AgentTemplates href(@javax.annotation.Nullable UUID href) {
+  public AgentTemplates href(@javax.annotation.Nullable URI href) {
     this.href = href;
     return this;
   }
@@ -171,11 +172,11 @@ public class AgentTemplates {
    * @return href
    */
   @javax.annotation.Nullable
-  public UUID getHref() {
+  public URI getHref() {
     return href;
   }
 
-  public void setHref(@javax.annotation.Nullable UUID href) {
+  public void setHref(@javax.annotation.Nullable URI href) {
     this.href = href;
   }
 


### PR DESCRIPTION
## Summary

- Add `AgentsApiTest` with read-only tests: `getAgents`, `getAgentByUuid`, `getAgentActivities`
- Add `AgentTemplatesApiTest` with tests: `getAgentTemplates`, `getAgentTemplateByUuid`
- Register `AgentsApi` and `AgentTemplatesApi` clients in `Apis.java`
- Add `agentsProjectId` field to `UsersItem` for agent-specific project configuration
- Fix `href` field type from `UUID` to `URI` in `AgentActivities` and `AgentTemplates` models (patch `002`)

## Test plan

- [x] Run `AgentsApiTest` against UAT: `mvn test "-Dtest=**/AgentsApiTest" -DenvUrl=https://uatapi.equinix.com`
- [x] Run `AgentTemplatesApiTest` against UAT: `mvn test "-Dtest=**/AgentTemplatesApiTest" -DenvUrl=https://uatapi.equinix.com`
- [ ] Tests using `Assume` skip gracefully when no agents are available